### PR TITLE
Add empty constructor

### DIFF
--- a/gamification/src/main/java/microservices/book/gamification/event/MultiplicationSolvedEvent.java
+++ b/gamification/src/main/java/microservices/book/gamification/event/MultiplicationSolvedEvent.java
@@ -21,4 +21,11 @@ class MultiplicationSolvedEvent implements Serializable {
     private final Long userId;
     private final boolean correct;
 
+    // Empty constructor for JSON/JPA
+    MultiplicationSolvedEvent() {
+        multiplicationResultAttemptId = 0L;
+        userId = 0L;
+        correct = false;
+    }
+
 }


### PR DESCRIPTION
Add empty constructor so gamification can successfully process messages from social-multipliation.

Without the empty constuctor the following error is thrown whenever gamification attempted to handle an incoming message: Could not read JSON: Can not construct instance of microservices.book.gamification.event.MultiplicationSolvedEvent: no suitable constructor found, can not deserialize from Object value (missing default constructor or creator, or perhaps need to add/enable type information?)